### PR TITLE
Removes `success` instance variable

### DIFF
--- a/lib/interaptor.rb
+++ b/lib/interaptor.rb
@@ -17,14 +17,14 @@ module Interaptor
       value = call!(*params)
 
       if @result && !@result.success?
-        return Interaptor::Result.new(success: false, errors: @result.errors)
+        return Interaptor::Result.new(errors: @result.errors)
       end
 
       return Interaptor::Result.new.tap do |result|
         result.value = value
       end
     rescue Interaptor::Failure => e
-      return Interaptor::Result.new(success: false, errors: e.errors)
+      return Interaptor::Result.new(errors: e.errors)
     end
 
   end
@@ -38,7 +38,7 @@ module Interaptor
   end
 
   def add_error(message, source: nil)
-    @result ||= Interaptor::Result.new(success: false)
+    @result ||= Interaptor::Result.new
     @result.add_error(Interaptor::Error.new(message, source))
   end
 

--- a/lib/interaptor/result.rb
+++ b/lib/interaptor/result.rb
@@ -2,8 +2,7 @@ class Interaptor::Result
 
   attr_accessor :value
 
-  def initialize(success: true, errors: [])
-    @success = success
+  def initialize(errors: [])
     @errors = errors
   end
 
@@ -12,11 +11,10 @@ class Interaptor::Result
   end
 
   def success?
-    @success && @errors.empty?
+    @errors.empty?
   end
 
   def add_error(error)
-    success = false
     @errors ||= []
     @errors << error
   end


### PR DESCRIPTION
Removes `success` instance variable and infer `success` by the absence of errors.
Removes success references from Result instantiation