### PR TITLE
raise error when fail! is called without errors

### DIFF
--- a/lib/interaptor.rb
+++ b/lib/interaptor.rb
@@ -45,6 +45,8 @@ module Interaptor
   def fail!(message=nil, source: nil)
     add_error(message, source: source) if message
 
+    raise 'You cannot call fail! with empty errors!' if @result.nil? || @result.errors.empty?
+
     raise Interaptor::Failure.new(@result ? @result.errors : [])
   end
 

--- a/lib/interaptor/result.rb
+++ b/lib/interaptor/result.rb
@@ -11,12 +11,11 @@ class Interaptor::Result
   end
 
   def success?
-    @errors.empty?
+    errors.empty?
   end
 
   def add_error(error)
-    @errors ||= []
-    @errors << error
+    errors << error
   end
 
 end

--- a/spec/interaptor_spec.rb
+++ b/spec/interaptor_spec.rb
@@ -56,6 +56,25 @@ RSpec.describe Interaptor do
       end
     end
 
+    describe 'failure without return with empty errors' do
+      subject(:interactor) do
+        build_interactor do
+          def execute
+            fail!
+          end
+        end
+      end
+
+      let(:result) { interactor.call }
+
+      it 'should raise an exception' do
+        expect { interactor.call! }.to raise_error do |error|
+          expect(error).to be_a RuntimeError
+          expect(error.message).to eq 'You cannot call fail! with empty errors!'
+        end
+      end
+    end
+
     describe 'failure with return' do
       subject(:interactor) do
         build_interactor do


### PR DESCRIPTION
As mentioned by @rafaeldalpra, `fail!` could not be called without args and without any errors.